### PR TITLE
fix(ci): make Kanban update steps non-blocking with continue-on-error

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,17 +35,18 @@ jobs:
 
       - name: Update Kanban to In Progress
         if: github.event_name == 'issues'
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
         run: |
-          if [ -n "$GH_TOKEN" ]; then
-            chmod +x .github/scripts/update-kanban.sh
-            .github/scripts/update-kanban.sh \
-              --issue ${{ github.event.issue.number }} \
-              --status "In Progress"
-          else
-            echo "PROJECT_TOKEN not set, skipping Kanban update"
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::warning::PROJECT_TOKEN not set, skipping Kanban update"
+            exit 0
           fi
+          chmod +x .github/scripts/update-kanban.sh
+          .github/scripts/update-kanban.sh \
+            --issue ${{ github.event.issue.number }} \
+            --status "In Progress"
 
       - name: Run Claude Code
         id: claude

--- a/.github/workflows/kanban-sync.yml
+++ b/.github/workflows/kanban-sync.yml
@@ -19,6 +19,7 @@ jobs:
 
       - name: PR Merged — Move linked issue to Done
         if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
         run: |
@@ -47,6 +48,7 @@ jobs:
 
       - name: Issue Reopened — Move back to In Progress
         if: github.event_name == 'issues' && github.event.action == 'reopened'
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
         run: |
@@ -62,6 +64,7 @@ jobs:
 
       - name: Issue Closed (not via PR) — Move to Done
         if: github.event_name == 'issues' && github.event.action == 'closed'
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
         run: |


### PR DESCRIPTION
The "Update Kanban to In Progress" step was failing and blocking the entire Claude Code workflow from running. Added continue-on-error: true to all Kanban steps so the main workflow proceeds even if PROJECT_TOKEN is missing or the Projects v2 API call fails.

https://claude.ai/code/session_0197vHsbcZPvWVVVPpdYgw4K