### PR TITLE
fix(ci): generate Prisma client before server compile/test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci
+      - name: Generate Prisma Client
+        run: npx prisma generate --schema packages/server/prisma/schema.prisma
       - name: Generate feature count
         run: node scripts/generate-feature-count.js
       - name: TypeCheck Client
@@ -64,6 +66,8 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci
+      - name: Generate Prisma Client
+        run: npx prisma generate --schema packages/server/prisma/schema.prisma
       - name: Generate feature count
         run: node scripts/generate-feature-count.js
       - name: Run Prisma Migrations
@@ -83,6 +87,8 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci
+      - name: Generate Prisma Client
+        run: npx prisma generate --schema packages/server/prisma/schema.prisma
       - name: Generate feature count
         run: node scripts/generate-feature-count.js
       - name: Build Client
@@ -121,6 +127,8 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci
+      - name: Generate Prisma Client
+        run: npx prisma generate --schema packages/server/prisma/schema.prisma
       - run: npx playwright install --with-deps chromium
       - name: Generate feature count
         run: node scripts/generate-feature-count.js


### PR DESCRIPTION
## Summary
- add `npx prisma generate --schema packages/server/prisma/schema.prisma` after `npm ci` in CI jobs that compile or execute server code
- apply this in `typecheck`, `unit-tests`, `build`, and `e2e-tests` jobs

## Why
GitHub runners start from a clean workspace, and server typecheck/build can run before Prisma client generation. That causes false-negative failures for Prisma namespace/types and stalls issue/PR completion.

## Validation
- `npm run typecheck`

Closes #50
