### PR TITLE
fix(ci): build server artifact before e2e start step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,8 @@ jobs:
         run: npx prisma generate --schema packages/server/prisma/schema.prisma
       - name: Generate feature count
         run: node scripts/generate-feature-count.js
+      - name: Build Server
+        run: npm run build --workspace=packages/server
       - name: Run Prisma Migrations
         run: npx prisma migrate deploy --schema packages/server/prisma/schema.prisma
       - name: Client Unit Tests


### PR DESCRIPTION
## Summary
- add a `Build Server` step in the `e2e-tests` job before `Start Server`

## Why
The e2e job starts `npm run start --workspace=packages/server`, which requires `packages/server/dist/server.js`. On fresh runners this artifact is absent unless the server is built in that same job.

## Evidence
- failing run: https://github.com/sarathfrancis90/grid-space/actions/runs/22767335394/job/66038768344
- error: `Cannot find module ... packages/server/dist/server.js`

Closes #59
